### PR TITLE
Using to TextMate::Executor

### DIFF
--- a/Commands/Run in SML.plist
+++ b/Commands/Run in SML.plist
@@ -7,10 +7,12 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env bash
-[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+	<string>#!/usr/bin/env ruby18
+require ENV["TM_SUPPORT_PATH"] + "/lib/tm/executor"
 
-"${TM_SML:-sml}"|pre</string>
+TextMate::Executor.make_project_master_current_document
+TextMate::Executor.run(ENV["TM_SML"] || "sml", ENV["TM_FILEPATH"])
+</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>inputFormat</key>


### PR DESCRIPTION
Using TextMate::Executor is possible to run SML script that import another files.
The example below will not work if I try to run `hw0test.sml`

``` sml
(* hw0provided.sml *)
(* Dan Grossman, Coursera PL, HW0 Provided Code *)
fun f(x,y) = x * y
fun double x = f(x,2)
fun triple x = f(3,x)
```

``` sml
(* hw0test.sml *)
(* Dan Grossman, Coursera PL, HW0 Provided Code *)
(* Homework0 Simple Test *)
use "hw0provided.sml";
val test1 = double 17 = 34
val test2 = double 0 = 0
val test3 = triple ~4 = ~12
```
