### PR TITLE
Fixed incorrect highlighting of 'type'

### DIFF
--- a/Syntaxes/Standard ML.plist
+++ b/Syntaxes/Standard ML.plist
@@ -214,7 +214,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\s*(type|eqtype) .* =</string>
+			<string>\b(type|eqtype) .* =</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
The current code incorrectly highlights 'type' in

    Hol_datatype `sample = Foo | Bar`;

which is erroneous.

A sample of this in the wild can be found at

https://github.com/HOL-Theorem-Prover/HOL/blob/master/examples/machine-code/instruction-set-models/x86_64/x64_coretypesScript.sml