### PR TITLE
fix: a few missing keywords and forms

### DIFF
--- a/Syntaxes/Standard ML.plist
+++ b/Syntaxes/Standard ML.plist
@@ -19,7 +19,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(val|datatype|struct|as|let|in|abstype|local|where|case|of|fn|raise|exception|handle|ref|infix|infixr|before|end|structure|withtype)\b</string>
+			<string>\b(val|datatype|signature|type|op|sharing|struct|as|let|in|abstype|local|where|case|of|fn|raise|exception|handle|ref|infix|infixr|before|end|structure|withtype)\b</string>
 			<key>name</key>
 			<string>keyword.other.ml</string>
 		</dict>


### PR DESCRIPTION
Keyword and forms to get Linguist on github to work correctly for syntactically correct SML and idiomatic pseudocode. Primarily it is to get the sml files in https://github.com/SMLFamily/BasisLibrary/tree/master/Code and code snippets in https://github.com/SMLFamily/BasisLibrary/blob/master/Code/example/example-proposal.md to highlight properly.
